### PR TITLE
refactor:  More circular reference resolution

### DIFF
--- a/dis_snek/models/__init__.py
+++ b/dis_snek/models/__init__.py
@@ -1,2 +1,3 @@
 from .discord import *
 from .snek import *
+from .utils import *

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -18,7 +18,7 @@ from dis_snek.client.utils.serializer import to_dict, to_image_data
 from dis_snek.models.discord.base import DiscordObject
 from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from dis_snek.models.discord.snowflake import Snowflake_Type, to_snowflake, to_optional_snowflake, SnowflakeObject
-from dis_snek.models.snek import AsyncIterator
+from dis_snek.models.utils import AsyncIterator
 from .enums import (
     ChannelTypes,
     OverwriteTypes,

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -5,7 +5,7 @@ import time
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
 from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from io import IOBase
-from dis_snek.models.snek import AsyncIterator
+from dis_snek.models.utils.iterator import AsyncIterator
 from aiohttp import FormData
 
 import dis_snek.models as models

--- a/dis_snek/models/discord/reaction.py
+++ b/dis_snek/models/discord/reaction.py
@@ -6,7 +6,7 @@ from dis_snek.client.const import MISSING
 from dis_snek.client.utils.attr_utils import define, field
 from dis_snek.models.discord.emoji import PartialEmoji
 from dis_snek.models.discord.snowflake import to_snowflake
-from dis_snek.models.snek.iterator import AsyncIterator
+from dis_snek.models.utils.iterator import AsyncIterator
 from .base import ClientObject
 
 if TYPE_CHECKING:

--- a/dis_snek/models/snek/__init__.py
+++ b/dis_snek/models/snek/__init__.py
@@ -7,7 +7,6 @@ from .command import *
 from .context import *
 from .converters import *
 from .cooldowns import *
-from .iterator import *
 from .listener import *
 from .protocols import *
 from .scale import *

--- a/dis_snek/models/utils/__init__.py
+++ b/dis_snek/models/utils/__init__.py
@@ -1,0 +1,3 @@
+from .iterator import AsyncIterator
+
+__all__ = ["AsyncIterator"]

--- a/dis_snek/models/utils/iterator.py
+++ b/dis_snek/models/utils/iterator.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator as _AsyncIterator
 from typing import List, Any
 
 from dis_snek.client.const import MISSING, Absent
-from dis_snek.models.discord.snowflake import to_snowflake, Snowflake_Type
+from dis_snek.models.discord import snowflake
 
 __all__ = ["AsyncIterator"]
 
@@ -81,9 +81,9 @@ class AsyncIterator(_AsyncIterator, ABC):
         """Flatten this iterator into a list of objects."""
         return [elem async for elem in self]
 
-    async def search(self, target_id: "Snowflake_Type") -> bool:
+    async def search(self, target_id: "snowflake.Snowflake_Type") -> bool:
         """Search the iterator for an object with the given ID."""
-        target_id = to_snowflake(target_id)
+        target_id = snowflake.to_snowflake(target_id)
 
         if target_id in [o.id for o in self._retrieved_objects]:
             return True


### PR DESCRIPTION
Puts AsyncIterator in models.utils, which can be safely imported by both snek and discord models.

It's not pretty, but it fixes the issue.  Besides, AsyncIterator never felt particularly like a Snek model, even if it does have a reference to Snowflakes in one of its methods